### PR TITLE
Enables save button in validation review

### DIFF
--- a/web_app/js/picker_review.js
+++ b/web_app/js/picker_review.js
@@ -61,6 +61,7 @@ var sortable_group = "";
 var sortable_group_list = [];
 var application = "";
 
+var reloaded = false;
 
 //
 //	Review
@@ -83,9 +84,12 @@ $(function() {
 		success: function(data) {
 
 			uid = data['uid'];
+			testset = data['className'];
 			IIPServer = data['IIPServer'];
 			posClass = data['posClass'];
 			negClass = data['negClass'];
+			curDataset = data['dataset'];
+			reloaded = data['reloaded'];
 
 			if( uid === null ) {
 				window.alert("No session active");
@@ -314,6 +318,7 @@ function create_mouse_event(sample, slide_num, sample_index){
 			updateLabels();
 			doreviewSel();
 			slidesInfo();
+			$('#saveBtn').removeAttr('disabled');
 
 		}, false);
 
@@ -746,6 +751,7 @@ function thumbDoubleClick(index) {
 	updateLabels();
 	doreviewSel();
 	slidesInfo(sampleDataJson['picker_review']);
+	$('#saveBtn').removeAttr('disabled');
 }
 
 
@@ -855,6 +861,49 @@ function onImageViewChanged(event) {
 }
 
 
+
+function saveTrainingSet() {
+
+	if( reloaded ) {
+
+		$.ajax({
+			type: "POST",
+			url: "php/finishReloadedPicker.php",
+			data: "",
+			dataType: "json",
+			success: function(data) {
+
+				if( data['status'] === "PASS" ) {
+					console.log("Pos: "+data['posClass']+", Neg: "+data['negClass']);
+					window.alert("Test set saved to: " + data['filename']);
+					window.location = "validation.html?application="+application;
+				} else {
+					window.alert("Unable to save test set");
+				}
+			},
+		});
+
+	} else {
+
+		$.ajax({
+			type: "POST",
+			url: "php/finishPicker.php",
+			data: "",
+			dataType: "json",
+			success: function(data) {
+
+				if( data['status'] === "PASS" ) {
+					console.log("Pos: "+data['posClass']+", Neg: "+data['negClass']);
+					window.alert("Test set saved to: " + data['filename']);
+					window.location = "validation.html?application="+application;
+				} else {
+					window.alert("Unable to save test set");
+				}
+			},
+		});
+
+	}
+}
 
 //
 // Retruns the value of the GET request variable specified by name


### PR DESCRIPTION
Enabled save button after changing samples in the review screen.

Basically, when a sample in the review screen is moved, this sample is automatically stored in local storage not database. The sample is finally stored in the database after clicking "save" button on picker screen. However, this would be not efficient for the users who want to save the sample on the review screen. So, enabled a save button on the review screen. This button will be enabled when the sample is moved on the review screen.

Note that if the user want to go back to picker screen, this button will be disabled because the save button on the picker screen will do the same work and the sample is already stored in the local storage. So, when the user goes back to review screen again and moves the samples, the save button on the review screen will be enabled again. 

      